### PR TITLE
Updated error handling logic, updated changelog, incremented dot-release to 1.0.6.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,3 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.6] - 2024-07-14
+
+### Changed
+- Changed record sorting logic
+- Changed error sorting logic
+- Changed error output to be more clear
+- Aligned error logic to account for the possibility of replies from DNS servers with unexpected records, such as SOA records on root domain when TXT records are requested for _dmarc subdomain only

--- a/Get-DMARCRecord/Get-DMARCRecord.psd1
+++ b/Get-DMARCRecord/Get-DMARCRecord.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Get-DMARCRecord.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.5'
+ModuleVersion = '1.0.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Updated error handling logic, updated changelog, incremented dot-release to 1.0.6

Fixed issue with reporting and clarity of errors in-cli.

Some hosts will not reply with errors or not-found. Sometimes, the reply
will be an SOA record, instead of an error record for _dmarc.$domain.
When this is not the case, it is not uncommon to find other forms of TXT
records and CNAME records hosted on _dmarc.$domain ; error handling has
been adjusted to relect this in the error messaging as well as update
the diagnostic info when using the -DisplayErrors parameter.

Removed extraneous -showRecord parameter which was a vestige from
initial development and testing when Get-DMARCRecord employed a
different output scheme.
